### PR TITLE
docs: Update README with GitHub Pages deployment info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@ Sorted
 ======
 
 [Playing around with HTML5 canvas and sorting algorithms](http://markberridge.github.io/sorted)
+
+## GitHub Pages Deployment
+
+This repository is structured to be deployed as a GitHub Pages site. The `index.html` file is the entry point, and all asset paths (CSS, JavaScript) are relative.
+
+To publish this site on GitHub Pages:
+1. Navigate to your repository's **Settings** tab on GitHub.
+2. In the left sidebar, click on **Pages**.
+3. Under "Build and deployment", for the **Source**, select **Deploy from a branch**.
+4. Choose the branch you want to deploy (e.g., `main` or `master`) and the `/ (root)` folder.
+5. Save the changes. GitHub will then build and deploy your site. You should see a URL where it's published.
+
+The existing link [Playing around with HTML5 canvas and sorting algorithms](http://markberridge.github.io/sorted) suggests this might already be set up for the original repository. These instructions are for deploying your own fork or if the settings need to be reconfigured.


### PR DESCRIPTION
The repository structure is already suitable for GitHub Pages. This commit adds a section to the README.md file to:
- Confirm its readiness for GitHub Pages deployment.
- Provide brief instructions on how to enable GitHub Pages in the repository settings.